### PR TITLE
Fix item/location count mismatch with extra stage and no shot type

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -114,8 +114,13 @@ class TWorld(World):
 
 			# If we are in practice mode and the stage progression is not progressive, we might have to change the quantity
 			if data.category == "Power Point" and mode == PRACTICE_MODE and stage_unlock != STAGE_GLOBAL:
-				# If we have no addition check, we remove 3 Power Point item
-				quantity = quantity-3 if not shot_type and not difficulty_check and extra == NO_EXTRA else quantity
+				# Reduce Power Points to match available locations
+				# Extra adds 6 locs but consumes 4 (stage unlock + endings), so only -1 vs -3
+				if not shot_type and not difficulty_check:
+					if extra == NO_EXTRA:
+						quantity -= 3
+					else:
+						quantity -= 1
 
 			# Will be added later
 			if data.category in ["[Global] Extra Stage", "[Character] Extra Stage", "[Shot Type] Extra Stage"]:


### PR DESCRIPTION
When shot_type and difficulty_check are both disabled, the Power Point quantity reduction only applied for NO_EXTRA (-3) but not for EXTRA_APART/EXTRA_LINEAR, causing 1 more item than available locations.

The extra stage adds 6 locations but consumes 4 with dedicated items (2 extra stage unlock items + 2 ending placements), leaving 2 net free pool slots. So Power Points only need to be reduced by 1 instead of 3.

This was found using this [fuzzer hook](https://github.com/Eijebong/Archipelago-fuzzer/blob/49a12deab5572bd8d315ca3028edfcbcca8ca3e5/hooks/item_location_count.py)